### PR TITLE
Split deployment workflow

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,4 +1,4 @@
-name: deploy
+name: generate-docs
 on:
   push:
     branches:
@@ -8,8 +8,7 @@ on:
       - 'serverless.yml'
       - 'package.json'
       - 'layer/**'
-      - 'set-klima-stocks.js'
-      - 'helpers/**'
+      - 'docs/**'
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_KEY_SECRET }}
@@ -18,7 +17,7 @@ env:
   ES_ENDPOINT: ${{ secrets.ES_ENDPOINT }}
   STOCKS_BUS_ARN: ${{ secrets.EB_STOCKS_BUS_ARN }}
 jobs:
-  deploy:
+  generate-docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -32,7 +31,16 @@ jobs:
       uses: serverless/github-action@master
       with:
         args: deploy --noDeploy
-    - name: serverless deploy
-      uses: serverless/github-action@master
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
       with:
-        args: deploy -v
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: lambda
+        template: docs/template.md

--- a/docs/template.md
+++ b/docs/template.md
@@ -4,9 +4,10 @@
 
 **GitHub Actions workflows status**
 
-[![](https://img.shields.io/github/workflow/status/kaskadi/set-klima-stocks/deploy?label=deployed&logo=Amazon%20AWS)](https://github.com/kaskadi/set-klima-stocks/actions?query=workflow%3Adeploy)
-[![](https://img.shields.io/github/workflow/status/kaskadi/set-klima-stocks/build?label=build&logo=mocha)](https://github.com/kaskadi/set-klima-stocks/actions?query=workflow%3Abuild)
-[![](https://img.shields.io/github/workflow/status/kaskadi/set-klima-stocks/syntax-check?label=syntax-check&logo=serverless)](https://github.com/kaskadi/set-klima-stocks/actions?query=workflow%3Asyntax-check)
+[![Deploy status](https://img.shields.io/github/workflow/status/kaskadi/set-klima-stocks/deploy?label=deployed&logo=Amazon%20AWS)](https://github.com/kaskadi/set-klima-stocks/actions?query=workflow%3Adeploy)
+[![Build status](https://img.shields.io/github/workflow/status/kaskadi/set-klima-stocks/build?label=build&logo=mocha)](https://github.com/kaskadi/set-klima-stocks/actions?query=workflow%3Abuild)
+[![Syntax check status](https://img.shields.io/github/workflow/status/kaskadi/set-klima-stocks/syntax-check?label=syntax-check&logo=serverless)](https://github.com/kaskadi/set-klima-stocks/actions?query=workflow%3Asyntax-check)
+[![Docs generation status](https://img.shields.io/github/workflow/status/kaskadi/set-klima-stocks/generate-docs?label=docs&logo=read-the-docs)](https://github.com/kaskadi/set-klima-stocks/actions?query=workflow%3Agenerate-docs)
 
 **CodeClimate**
 


### PR DESCRIPTION
**Changes description**
Extracted `generate-docs` step from `deploy` workflow into a separate workflow. Both workflow checks for syntax error in `serverless.yml`. This was done to prevent deployment for failing in case the workflow couldn't generate the documentation automatically (we don't need an up to date documentation to deploy resources).

**New features**
- _`generate-docs` workflow:_ former `generate-docs` step of `deploy` workflow. Now also checks for syntax error in config file.

**Updated features**
- _`deploy` workflow:_ removed `generate-docs` step and fixed triggers.